### PR TITLE
Fixed broken TypeScript package dependency resolution.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "grunt": "^0.4.5",
     "grunt-typescript": "^0.4.5",
     "jit-grunt": "^0.9.0",
-    "typescript": "^1.3.0"
+    "typescript": "1.3.x"
   },
   "devDependencies": {
     "grunt-contrib-less": "^0.12.0",


### PR DESCRIPTION
I encountered a dependency resolution b/c a package attempted to load a newer version of TypeScript, but a different package didn't support the new TypeScript version. The long-term fix may be to upgrade the package using the old version, but this should fix the issue for now.